### PR TITLE
Follow upstream yarn version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ that current provide custom panels are:
 
 - Dynalite
 - Insteon
-- panel
+- KNX
 
 This template is also intended to make it easier for integrations to upgrade thier custom panel to utilize the latest Home Assistant frontend
 version.

--- a/script/merge_dependencies.js
+++ b/script/merge_dependencies.js
@@ -1,4 +1,4 @@
-import fs from "fs"
+import fs from "fs";
 
 let rawcore = fs.readFileSync("./homeassistant-frontend/package.json");
 let rawapp = fs.readFileSync("./package.json.project");
@@ -6,10 +6,13 @@ let rawapp = fs.readFileSync("./package.json.project");
 const core = JSON.parse(rawcore);
 const app = JSON.parse(rawapp);
 
+const yarnDirRegExp = /\.yarn\//g;
+const yarnDirSubModule = "homeassistant-frontend/.yarn/";
+
 for (let k in core.resolutions) {
   core.resolutions[k] = core.resolutions[k].replace(
-    "./.yarn/",
-    "./homeassistant-frontend/.yarn/"
+    yarnDirRegExp,
+    yarnDirSubModule
   );
 }
 
@@ -32,6 +35,9 @@ fs.writeFileSync(
   )
 );
 
-const yarnRcCore = fs.readFileSync("./homeassistant-frontend/.yarnrc.yml", "utf8");
-const yarnRcApp = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/");
+const yarnRcCore = fs.readFileSync(
+  "./homeassistant-frontend/.yarnrc.yml",
+  "utf8"
+);
+const yarnRcApp = yarnRcCore.replace(yarnDirRegExp, yarnDirSubModule);
 fs.writeFileSync("./.yarnrc.yml", yarnRcApp);

--- a/script/merge_dependencies.js
+++ b/script/merge_dependencies.js
@@ -25,8 +25,13 @@ fs.writeFileSync(
         ...core.devDependencies,
       },
       prettier: { ...app.prettier, ...core.prettier },
+      packageManager: core.packageManager,
     },
     null,
     2
   )
 );
+
+const yarnRcCore = fs.readFileSync("./homeassistant-frontend/.yarnrc.yml", "utf8");
+const yarnRcKnx = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/");
+fs.writeFileSync("./.yarnrc.yml", yarnRcKnx);

--- a/script/merge_dependencies.js
+++ b/script/merge_dependencies.js
@@ -33,5 +33,5 @@ fs.writeFileSync(
 );
 
 const yarnRcCore = fs.readFileSync("./homeassistant-frontend/.yarnrc.yml", "utf8");
-const yarnRcKnx = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/");
-fs.writeFileSync("./.yarnrc.yml", yarnRcKnx);
+const yarnRcApp = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/");
+fs.writeFileSync("./.yarnrc.yml", yarnRcApp);

--- a/templates/package.json.project
+++ b/templates/package.json.project
@@ -32,6 +32,5 @@
   "resolutions": {
   },
   "prettier": {
-  },
-  "packageManager": "yarn@3.5.1"
+  }
 }


### PR DESCRIPTION
When HA-FE updates their yarn version, 
https://github.com/ha-custom-panel/template/blob/025d5682244235ddda5801aa253a35f396a677e5/.yarnrc.yaml#L11
is no longer available. So we should update our `.yarnrc` to point to the correct file.
Same for `packageManager` in `project.json`.