### PR TITLE
Python helper functions

### DIFF
--- a/build-scripts/gulp/entry-html.js
+++ b/build-scripts/gulp/entry-html.js
@@ -8,8 +8,7 @@ import paths from "../paths.cjs";
 gulp.task("gen-index-panel-dev", async () => {
   writepanelEntrypoint(
     `${paths.panel_publicPath}/frontend_latest/entrypoint-dev.js`,
-    `${paths.panel_publicPath}/frontend_es5/entrypoint-dev.js`,
-    "True"
+    `${paths.panel_publicPath}/frontend_es5/entrypoint-dev.js`
   );
 });
 
@@ -22,12 +21,11 @@ gulp.task("gen-index-panel-prod", async () => {
   );
   writepanelEntrypoint(
     latestManifest["entrypoint.js"],
-    es5Manifest["entrypoint.js"],
-    "False"
+    es5Manifest["entrypoint.js"]
   );
 });
 
-function writepanelEntrypoint(latestEntrypoint, es5Entrypoint, isDev) {
+function writepanelEntrypoint(latestEntrypoint, es5Entrypoint) {
   const fileElements = latestEntrypoint.split("-");
   const fileHash = fileElements[1].split(".")[0];
   fs.mkdirSync(paths.panel_output_root, { recursive: true });
@@ -54,9 +52,7 @@ if (/.*Version\\/(?:11|12)(?:\\.\\d+)*.*Safari\\//.test(navigator.userAgent)) {
   );
   fs.writeFileSync(
     path.resolve(paths.panel_output_root, "constants.py"),
-    `FILE_HASH = '${fileHash}'
-DEV = ${isDev}
-`,
+    `FILE_HASH = '${fileHash}'`,
     { encoding: "utf-8" }
   );
   fs.copyFileSync(

--- a/templates/ha_integration_snippets/README.md
+++ b/templates/ha_integration_snippets/README.md
@@ -1,0 +1,3 @@
+# Home Assistant Integration
+
+These snippets show how to load a panel in Home Assistant when the accompanying integration is loaded via ConfigEntry.

--- a/templates/ha_integration_snippets/__init__.py
+++ b/templates/ha_integration_snippets/__init__.py
@@ -1,0 +1,12 @@
+"""Integration for Home Assistant."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .panel import register_panel
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Load a config entry."""
+    ...
+    await register_panel(hass=hass)
+    return True

--- a/templates/ha_integration_snippets/const.py
+++ b/templates/ha_integration_snippets/const.py
@@ -1,0 +1,4 @@
+"""Constants for the integration."""
+from typing import Final
+
+DOMAIN: Final = "my_integration"

--- a/templates/ha_integration_snippets/manifest.json
+++ b/templates/ha_integration_snippets/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "...",
+  "name": "...",
+  "after_dependencies": ["panel_custom"],
+  "codeowners": [],
+  "dependencies": ["websocket_api"],
+  "documentation": "...",
+  "integration_type": "...",
+  "iot_class": "...",
+  "requirements": ["<panel_package_name>==<versoion>"]
+}

--- a/templates/ha_integration_snippets/panel.py
+++ b/templates/ha_integration_snippets/panel.py
@@ -1,0 +1,32 @@
+"""Panel and Websocket API."""
+from __future__ import annotations
+
+from typing import Final
+
+from homeassistant.components import panel_custom
+from homeassistant.core import HomeAssistant
+from panel_package_name import entrypoint_js, is_dev_build, locate_dir
+
+from .const import DOMAIN
+
+URL_BASE: Final = "/panel_static"  # build-scripts/paths.cjs -> panel_publicPath
+
+
+async def register_panel(hass: HomeAssistant) -> None:
+    """Register the Panel."""
+    if DOMAIN not in hass.data.get("frontend_panels", {}):
+        hass.http.register_static_path(
+            url_path=URL_BASE,
+            path=locate_dir(),
+            cache_headers=not is_dev_build,
+        )
+        await panel_custom.async_register_panel(
+            hass=hass,
+            frontend_url_path=DOMAIN,
+            webcomponent_name="panel_frontend_name",  # custom element name from `main.ts`
+            sidebar_title=DOMAIN.title(),
+            sidebar_icon="mdi:human-greeting",
+            module_url=f"{URL_BASE}/{entrypoint_js}",
+            embed_iframe=True,
+            require_admin=True,
+        )

--- a/templates/ha_integration_snippets/panel.py
+++ b/templates/ha_integration_snippets/panel.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import Final
 
+import panel_package_name as my_panel
 from homeassistant.components import panel_custom
 from homeassistant.core import HomeAssistant
-from panel_package_name import entrypoint_js, is_dev_build, locate_dir
 
 from .const import DOMAIN
 
@@ -16,17 +16,17 @@ async def register_panel(hass: HomeAssistant) -> None:
     """Register the Panel."""
     if DOMAIN not in hass.data.get("frontend_panels", {}):
         hass.http.register_static_path(
-            url_path=URL_BASE,
-            path=locate_dir(),
-            cache_headers=not is_dev_build(),
+            URL_BASE,
+            path=my_panel.locate_dir(),
+            cache_headers=my_panel.is_prod_build,
         )
         await panel_custom.async_register_panel(
             hass=hass,
             frontend_url_path=DOMAIN,
-            webcomponent_name="panel_frontend_name",  # custom element name from `main.ts`
+            webcomponent_name=my_panel.webcomponent_name,
             sidebar_title=DOMAIN.title(),
             sidebar_icon="mdi:human-greeting",
-            module_url=f"{URL_BASE}/{entrypoint_js()}",
+            module_url=f"{URL_BASE}/{my_panel.entrypoint_js}",
             embed_iframe=True,
             require_admin=True,
         )

--- a/templates/ha_integration_snippets/panel.py
+++ b/templates/ha_integration_snippets/panel.py
@@ -18,7 +18,7 @@ async def register_panel(hass: HomeAssistant) -> None:
         hass.http.register_static_path(
             url_path=URL_BASE,
             path=locate_dir(),
-            cache_headers=not is_dev_build,
+            cache_headers=not is_dev_build(),
         )
         await panel_custom.async_register_panel(
             hass=hass,
@@ -26,7 +26,7 @@ async def register_panel(hass: HomeAssistant) -> None:
             webcomponent_name="panel_frontend_name",  # custom element name from `main.ts`
             sidebar_title=DOMAIN.title(),
             sidebar_icon="mdi:human-greeting",
-            module_url=f"{URL_BASE}/{entrypoint_js}",
+            module_url=f"{URL_BASE}/{entrypoint_js()}",
             embed_iframe=True,
             require_admin=True,
         )

--- a/templates/src/__init__.py
+++ b/templates/src/__init__.py
@@ -1,5 +1,7 @@
 """Panel module."""
-from .constants import FILE_HASH
+from typing import Final
+
+from .const import FILE_HASH
 
 
 def locate_dir() -> str:
@@ -7,16 +9,11 @@ def locate_dir() -> str:
     return __path__[0]
 
 
-def get_build_id() -> str:
-    """Get the panel build id."""
-    return FILE_HASH
+# Filename of the entrypoint.js to import the panel
+entrypoint_js: Final = f"entrypoint-{FILE_HASH}.js"
 
+# The webcomponent name that loads the panel (main.ts)
+webcomponent_name: Final = "knx-frontend"
 
-def is_dev_build() -> bool:
-    """Check if this is a dev build."""
-    return FILE_HASH == "dev"
-
-
-def entrypoint_js() -> str:
-    """Return the name of the entrypoint js file."""
-    return f"entrypoint-{FILE_HASH}.js"
+is_dev_build: Final = FILE_HASH == "dev"
+is_prod_build: Final = not is_dev_build

--- a/templates/src/__init__.py
+++ b/templates/src/__init__.py
@@ -1,1 +1,22 @@
-"""Do nothing."""
+"""Panel module."""
+from .constants import FILE_HASH
+
+
+def locate_dir() -> str:
+    """Return the location of the frontend files."""
+    return __path__[0]
+
+
+def get_build_id() -> str:
+    """Get the panel build id."""
+    return FILE_HASH
+
+
+def is_dev_build() -> bool:
+    """Check if this is a dev build."""
+    return FILE_HASH == "dev"
+
+
+def entrypoint_js() -> str:
+    """Return the name of the entrypoint js file."""
+    return f"entrypoint-{FILE_HASH}.js"

--- a/templates/src/const.py
+++ b/templates/src/const.py
@@ -1,0 +1,9 @@
+"""
+Constants for the panel.
+
+
+For builds, this file is generated entirely by in build-scripts/gulp/entry-html.js
+changes here aren't reflected.
+"""
+
+FILE_HASH = "dev"


### PR DESCRIPTION
Add some convenience functions for the panel to be registered. This could be used like:

```py
import panel_package_name as my_panel

async def register_panel(hass: HomeAssistant) -> None:
    """Register the Panel."""
    if DOMAIN not in hass.data.get("frontend_panels", {}):
        hass.http.register_static_path(
            URL_BASE,
            path=my_panel.locate_dir(),
            cache_headers=my_panel.is_prod_build,
        )
        await panel_custom.async_register_panel(
            hass=hass,
            frontend_url_path=DOMAIN,
            webcomponent_name=my_panel.webcomponent_name,
            sidebar_title=DOMAIN.title(),
            sidebar_icon="mdi:human-greeting",
            module_url=f"{URL_BASE}/{my_panel.entrypoint_js}",
            embed_iframe=True,
            require_admin=True,
        )
```

Maybe also add `panel_publicPath` which in the example would be the hardcoded `URL_BASE`